### PR TITLE
Add user controller and mapstruct DTO mapping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,17 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>1.5.5.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>1.5.5.Final</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -96,6 +107,13 @@
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>1.5.5.Final</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/example/multidatasoure/controller/AdminController.java
+++ b/src/main/java/com/example/multidatasoure/controller/AdminController.java
@@ -1,6 +1,7 @@
 package com.example.multidatasoure.controller;
 
-import com.example.multidatasoure.entity.primary.User;
+import com.example.multidatasoure.dto.UserResponse;
+import com.example.multidatasoure.mapper.UserMapper;
 import com.example.multidatasoure.repository.primary.UserRepository;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,13 +14,17 @@ import java.util.List;
 public class AdminController {
 
     private final UserRepository userRepository;
+    private final UserMapper userMapper;
 
-    public AdminController(UserRepository userRepository) {
+    public AdminController(UserRepository userRepository, UserMapper userMapper) {
         this.userRepository = userRepository;
+        this.userMapper = userMapper;
     }
 
     @GetMapping("/users")
-    public List<User> allUsers() {
-        return userRepository.findAll();
+    public List<UserResponse> allUsers() {
+        return userRepository.findAll().stream()
+                .map(userMapper::toUserResponse)
+                .toList();
     }
 }

--- a/src/main/java/com/example/multidatasoure/controller/AuthController.java
+++ b/src/main/java/com/example/multidatasoure/controller/AuthController.java
@@ -3,7 +3,8 @@ package com.example.multidatasoure.controller;
 import com.example.multidatasoure.dto.ForgotPasswordRequest;
 import com.example.multidatasoure.dto.LoginRequest;
 import com.example.multidatasoure.dto.UserDto;
-import com.example.multidatasoure.entity.primary.User;
+import com.example.multidatasoure.dto.UserResponse;
+import com.example.multidatasoure.mapper.UserMapper;
 import com.example.multidatasoure.service.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,14 +14,16 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final UserService userService;
+    private final UserMapper userMapper;
 
-    public AuthController(UserService userService) {
+    public AuthController(UserService userService, UserMapper userMapper) {
         this.userService = userService;
+        this.userMapper = userMapper;
     }
 
     @PostMapping("/register")
-    public ResponseEntity<User> register(@RequestBody UserDto dto) {
-        return ResponseEntity.ok(userService.register(dto));
+    public ResponseEntity<UserResponse> register(@RequestBody UserDto dto) {
+        return ResponseEntity.ok(userMapper.toUserResponse(userService.register(dto)));
     }
 
     @PostMapping("/login")
@@ -35,8 +38,9 @@ public class AuthController {
     }
 
     @PutMapping("/user/{id}")
-    public ResponseEntity<User> editUser(@PathVariable Long id, @RequestBody UserDto dto) {
+    public ResponseEntity<UserResponse> editUser(@PathVariable Long id, @RequestBody UserDto dto) {
         return userService.editUser(id, dto)
+                .map(userMapper::toUserResponse)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }

--- a/src/main/java/com/example/multidatasoure/controller/UserController.java
+++ b/src/main/java/com/example/multidatasoure/controller/UserController.java
@@ -1,0 +1,32 @@
+package com.example.multidatasoure.controller;
+
+import com.example.multidatasoure.dto.UserResponse;
+import com.example.multidatasoure.mapper.UserMapper;
+import com.example.multidatasoure.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class UserController {
+
+    private final UserService userService;
+    private final UserMapper userMapper;
+
+    public UserController(UserService userService, UserMapper userMapper) {
+        this.userService = userService;
+        this.userMapper = userMapper;
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<UserResponse> me(Authentication authentication) {
+        return userService.findByUsername(authentication.getName())
+                .map(userMapper::toUserResponse)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+}
+

--- a/src/main/java/com/example/multidatasoure/dto/UserResponse.java
+++ b/src/main/java/com/example/multidatasoure/dto/UserResponse.java
@@ -1,0 +1,13 @@
+package com.example.multidatasoure.dto;
+
+import com.example.multidatasoure.entity.primary.Role;
+import lombok.Data;
+
+@Data
+public class UserResponse {
+    private Long id;
+    private String username;
+    private String email;
+    private Role role;
+}
+

--- a/src/main/java/com/example/multidatasoure/mapper/UserMapper.java
+++ b/src/main/java/com/example/multidatasoure/mapper/UserMapper.java
@@ -1,0 +1,12 @@
+package com.example.multidatasoure.mapper;
+
+import org.mapstruct.Mapper;
+
+import com.example.multidatasoure.dto.UserResponse;
+import com.example.multidatasoure.entity.primary.User;
+
+@Mapper(componentModel = "spring")
+public interface UserMapper {
+    UserResponse toUserResponse(User user);
+}
+

--- a/src/main/java/com/example/multidatasoure/service/UserService.java
+++ b/src/main/java/com/example/multidatasoure/service/UserService.java
@@ -48,6 +48,10 @@ public class UserService {
         return jwtTokenProvider.createToken(auth);
     }
 
+    public Optional<User> findByUsername(String username) {
+        return userRepository.findByUsername(username);
+    }
+
     public Optional<User> editUser(Long id, UserDto dto) {
         return userRepository.findById(id).map(user -> {
             if (dto.getEmail() != null) {


### PR DESCRIPTION
## Summary
- add MapStruct dependency and configuration
- introduce UserResponse DTO and mapper
- add user controller with `/api/me` endpoint
- return DTOs from existing auth and admin controllers

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_689ae7b7152c833391c9a514bbc5bdc4