### PR TITLE
Run log entry migrations on secondary database

### DIFF
--- a/src/main/java/com/example/multidatasoure/config/SecondaryDataSourceConfig.java
+++ b/src/main/java/com/example/multidatasoure/config/SecondaryDataSourceConfig.java
@@ -13,6 +13,8 @@ import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import liquibase.integration.spring.SpringLiquibase;
+
 @Configuration
 @EnableJpaRepositories(
         basePackages = "com.example.multidatasoure.repository.secondary",
@@ -33,13 +35,21 @@ public class SecondaryDataSourceConfig {
     }
 
     @Bean
-    public LocalContainerEntityManagerFactoryBean secondaryEntityManagerFactory() {
-        LocalContainerEntityManagerFactoryBean emf = new LocalContainerEntityManagerFactoryBean();
-        emf.setDataSource(secondaryDataSource());
-        emf.setPackagesToScan("com.example.multidatasoure.entity.secondary");
-        emf.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
-        return emf;
-    }
+      public LocalContainerEntityManagerFactoryBean secondaryEntityManagerFactory() {
+          LocalContainerEntityManagerFactoryBean emf = new LocalContainerEntityManagerFactoryBean();
+          emf.setDataSource(secondaryDataSource());
+          emf.setPackagesToScan("com.example.multidatasoure.entity.secondary");
+          emf.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
+          return emf;
+      }
+
+      @Bean
+      public SpringLiquibase secondaryLiquibase() {
+          SpringLiquibase liquibase = new SpringLiquibase();
+          liquibase.setDataSource(secondaryDataSource());
+          liquibase.setChangeLog("classpath:db/changelog/db.changelog-secondary.xml");
+          return liquibase;
+      }
 
     @Bean
     public PlatformTransactionManager secondaryTransactionManager(

--- a/src/main/resources/db/changelog/2024-02-23-00-00-00-changelog.xml
+++ b/src/main/resources/db/changelog/2024-02-23-00-00-00-changelog.xml
@@ -23,14 +23,4 @@
             </column>
         </createTable>
     </changeSet>
-
-    <changeSet id="2" author="agent">
-        <createTable tableName="log_entries">
-            <column name="id" type="BIGSERIAL">
-                <constraints primaryKey="true" nullable="false"/>
-            </column>
-            <column name="message" type="VARCHAR(255)"/>
-        </createTable>
-    </changeSet>
-
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-secondary.xml
+++ b/src/main/resources/db/changelog/db.changelog-secondary.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd">
+
+    <changeSet id="1" author="agent">
+        <createTable tableName="log_entries">
+            <column name="id" type="BIGSERIAL">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="message" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Summary
- separate log entry migration into its own Liquibase changelog
- wire Liquibase to the secondary datasource so log entries are created in the correct database

## Testing
- `mvn test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_689aeabdd7848333a19bff42e5708211