### PR TITLE
fix: correct liquibase changelog paths

### DIFF
--- a/src/main/resources/db/changelog/2025-02-23-00-00-00-changelog.xml
+++ b/src/main/resources/db/changelog/2025-02-23-00-00-00-changelog.xml
@@ -2,7 +2,7 @@
 <databaseChangeLog
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd">
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
 
     <changeSet id="1" author="agent">
         <createTable tableName="users">
@@ -21,14 +21,6 @@
             <column name="role" type="VARCHAR(50)">
                 <constraints nullable="false"/>
             </column>
-        </createTable>
-    </changeSet>
-    <changeSet id="2" author="agent">
-        <createTable tableName="log_entries">
-            <column name="id" type="BIGSERIAL">
-                <constraints primaryKey="true" nullable="false"/>
-            </column>
-            <column name="message" type="VARCHAR(255)"/>
         </createTable>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/2025-02-23-00-00-01-changelog.xml
+++ b/src/main/resources/db/changelog/2025-02-23-00-00-01-changelog.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <databaseChangeLog
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd"
-        logicalFilePath="db/changelog/db.changelog-master.xml">
-    <include file="/db/changelog/2025-02-23-00-00-00-changelog.xml"/>
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+    <changeSet id="1" author="agent">
+        <createTable tableName="log_entries">
+            <column name="id" type="BIGSERIAL">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="message" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -5,5 +5,5 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd"
         logicalFilePath="db/changelog/db.changelog-master.xml">
-    <include file="/db/changelog/2025-02-23-00-00-00-changelog.xml"/>
+    <include relativeToChangelogFile="true" file="2025-02-23-00-00-00-changelog.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-secondary.xml
+++ b/src/main/resources/db/changelog/db.changelog-secondary.xml
@@ -5,5 +5,5 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd"
         logicalFilePath="db/changelog/db.changelog-secondary.xml">
-    <include file="/db/changelog/2025-02-23-00-00-01-changelog.xml"/>
+    <include relativeToChangelogFile="true" file="2025-02-23-00-00-01-changelog.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
## Summary
- use relative includes for Liquibase primary and secondary changelogs
- split user and log entry schema into separate change sets per data source

## Testing
- `mvn -q spring-boot:run` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_689af11f12648333a6623349ac6ea836