### PR TITLE
Join employee profile organizations in filter

### DIFF
--- a/src/main/java/com/example/multidatasoure/controller/request/AbstractEmployeeFilter.java
+++ b/src/main/java/com/example/multidatasoure/controller/request/AbstractEmployeeFilter.java
@@ -1,5 +1,6 @@
 package com.example.multidatasoure.controller.request;
 
+import com.example.multidatasoure.entity.primary.EmployeeProfile;
 import com.example.multidatasoure.entity.primary.Organization;
 import com.example.multidatasoure.entity.primary.User;
 import org.springframework.data.jpa.domain.Specification;
@@ -14,13 +15,13 @@ public abstract class AbstractEmployeeFilter {
     }
 
     protected Specification<User> byOrganizationId(Long organizationId) {
-        return (root, query, criteriaBuilder) -> {
-            if (organizationId == null) {
-                return null;
-            } else {
-                return criteriaBuilder.equal(root.get(User.Fields.organizations).get(Organization.Fields.id), organizationId);
-            }
-        };
+        return (root, query, cb) -> organizationId == null ? null :
+                cb.equal(
+                        root.join(User.Fields.employeeProfile)
+                                .join(EmployeeProfile.Fields.organizations)
+                                .get(Organization.Fields.id),
+                        organizationId
+                );
     }
 
 }

--- a/src/main/java/com/example/multidatasoure/entity/primary/EmployeeProfile.java
+++ b/src/main/java/com/example/multidatasoure/entity/primary/EmployeeProfile.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.FieldNameConstants;
 import org.hibernate.proxy.HibernateProxy;
 
 import java.util.ArrayList;
@@ -29,6 +30,7 @@ import java.util.Objects;
 @AllArgsConstructor
 @Entity
 @Table(name = "employees_profiles")
+@FieldNameConstants
 public class EmployeeProfile {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## Summary
- join through employeeProfile.organizations when filtering employees by organization ID
- generate field-name constants for EmployeeProfile for safe joins

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a8855bf0ec83338777627ded83d8b5